### PR TITLE
feat(options): add options to control cache duration

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,13 +10,12 @@
     "webNavigation",
     "notifications"
   ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.js"
   },
   "action": {
     "default_popup": "popup.html"
-  }
+  },
+  "options_page": "options.html"
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>External Resource Scanner Options</title>
+  </head>
+  <body>
+    <label for="cache-duration">Cache Duration in ms:</label>
+    <input type="number" id="cache-duration" />
+
+    <button id="save">Save</button>
+
+    <div id="status"></div>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,29 @@
+const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
+const saveOptions = () => {
+    const cacheDuration = document.getElementById('cache-duration').value;
+
+    chrome.storage.sync.set(
+        { cacheDuration },
+        () => {
+            // Update status to let user know options were saved.
+            const status = document.getElementById('status');
+            status.textContent = 'Options saved.';
+            setTimeout(() => {
+                status.textContent = '';
+            }, 750);
+        }
+    );
+};
+
+const restoreOptions = () => {
+    chrome.storage.sync.get(
+        { cacheDuration: WEEK_IN_MS },
+        (items) => {
+            document.getElementById('cache-duration').value = items.cacheDuration;
+        }
+    );
+};
+
+document.addEventListener('DOMContentLoaded', restoreOptions);
+document.getElementById('save').addEventListener('click', saveOptions);

--- a/popup.html
+++ b/popup.html
@@ -2,58 +2,82 @@
 <!-- (c) Lauritz Holtmann -->
 <!-- https://github.com/lauritzh/dead-domain-discovery -->
 <html>
-<head>
-  <title>External Resource Scanner</title>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      background-color: #f4f4f9;
-      min-width:250px;
-      color: #333;
-    }
-    h1 {
-      font-size: 18px;
-      margin-bottom: 10px;
-      color: #2c3e50;
-    }
-    p {
-      font-size: 12px;
-      margin: 0 0 20px;
-      color: #7f8c8d;
-    }
-    ul {
-      list-style-type: none;
-      padding: 0;
-    }
-    li {
-      margin: 5px 0;
-    }
-    a {
-      text-decoration: none;
-      color: #3498db;
-      font-size: 14px;
-    }
-    a:hover {
-      text-decoration: underline;
-    }
-    .footer {
-      font-size: 12px;
-      margin-top: 20px;
-      color: #95a5a6;
-    }
-  </style>
-</head>
-<body>
-  <h1>Dead Domain Discovery v0.2</h1>
-  <p>&copy; Lauritz Holtmann</p>
-  <ul>
-    <li><a href="https://hackerone.com/lauritz" target="_blank">H1: lauritz</a></li>
-    <li><a href="https://yeswehack.com/hunters/lauritz" target="_blank">YWH: lauritz</a></li>
-    <li><a href="https://app.intigriti.com/researcher/profile/_lauritz_" target="_blank">Intigriti: _lauritz_</a></li>
-    <li><a href="https://bugcrowd.com/lauritz" target="_blank">Bugcrowd: lauritz</a></li>
-  </ul>
-  <div class="footer">
-    <p><a href="https://github.com/lauritzh/dead-domain-discovery" target="_blank">GitHub Repository</a></p>
-  </div>
-</body>
+  <head>
+    <title>External Resource Scanner</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background-color: #f4f4f9;
+        min-width: 250px;
+        color: #333;
+      }
+      h1 {
+        font-size: 18px;
+        margin-bottom: 10px;
+        color: #2c3e50;
+      }
+      p {
+        font-size: 12px;
+        margin: 0 0 20px;
+        color: #7f8c8d;
+      }
+      ul {
+        list-style-type: none;
+        padding: 0;
+      }
+      li {
+        margin: 5px 0;
+      }
+      a {
+        text-decoration: none;
+        color: #3498db;
+        font-size: 14px;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      .footer {
+        font-size: 12px;
+        margin-top: 20px;
+        color: #95a5a6;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Dead Domain Discovery v0.2</h1>
+    <p>&copy; Lauritz Holtmann</p>
+    <ul>
+      <li>
+        <a href="https://hackerone.com/lauritz" target="_blank">H1: lauritz</a>
+      </li>
+      <li>
+        <a href="https://yeswehack.com/hunters/lauritz" target="_blank"
+          >YWH: lauritz</a
+        >
+      </li>
+      <li>
+        <a
+          href="https://app.intigriti.com/researcher/profile/_lauritz_"
+          target="_blank"
+          >Intigriti: _lauritz_</a
+        >
+      </li>
+      <li>
+        <a href="https://bugcrowd.com/lauritz" target="_blank"
+          >Bugcrowd: lauritz</a
+        >
+      </li>
+    </ul>
+    <div class="footer">
+      <p>
+        <a
+          href="https://github.com/lauritzh/dead-domain-discovery"
+          target="_blank"
+          >GitHub Repository</a
+        >
+      </p>
+      <p><button id="go-to-options">Go to options</button></p>
+    </div>
+    <script src="popup.js"></script>
+  </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,5 @@
+document
+    .querySelector("#go-to-options")
+    .addEventListener("click", function () {
+        chrome.runtime.openOptionsPage();
+    });


### PR DESCRIPTION
Adds options to the extension that can either be opened by rightclicking the extension icon, or the "options" button in the UI.

Options right now contain only `cacheDuration` to control the duration resolved domains are cached. By default this will fallback to a week.