### PR TITLE
Fix e-mail domain handling

### DIFF
--- a/build_extension.sh
+++ b/build_extension.sh
@@ -9,9 +9,12 @@ ZIP_FILE="dead_domain_discovery_$CURRENT_DATE.zip"
 # List of files to include in the zip file based on the manifest
 FILES=(
   "manifest.json"
+  "content.js"
   "background.js"
   "popup.html"
+  "popup.js"
   "options.html"
+  "options.js"
   "icons/icon16.png"
   "icons/icon32.png"
   "icons/icon48.png"

--- a/content.js
+++ b/content.js
@@ -50,7 +50,7 @@ function scanPage() {
     if (href && isHttpUrl(href)) {
       resources.anchors.push({ url: href, element: 'a' });
     } else if (href && href.startsWith('mailto:')) {
-      resources.anchors.push({ url: href.replace('mailto:','mailto://'), element: 'a > mailto' });
+      resources.anchors.push({ url: href.replace('mailto://','mailto:').replace('mailto:','mailto://').replace('%40','@'), element: 'a > mailto' });
     }
   });
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dead Domain Discovery",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Scans the page for external iFrames, Scripts, and Styles, logs them to the console, and checks if their domains are resolvable.",
   "permissions": [
     "activeTab",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dead Domain Discovery",
-  "version": "0.7",
+  "version": "0.7.1",
   "description": "Scans the page for external iFrames, Scripts, and Styles, logs them to the console, and checks if their domains are resolvable.",
   "permissions": [
     "activeTab",

--- a/popup.html
+++ b/popup.html
@@ -68,7 +68,7 @@
     </style>
   </head>
   <body>
-    <h1>Dead Domain Discovery v0.7</h1>
+    <h1>Dead Domain Discovery v0.7.2</h1>
     <div class="stats">
       <p id="domain-stats">Found 0 Dead Domains</p>
     </div>


### PR DESCRIPTION
`%40` was not correctly URL decoded, leading to erroneous lookups of domains such as `mailbox%40domain.tld` and consequently false positives. 